### PR TITLE
Increment elm-codegen to 4.0.1, add example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,42 @@ The main disadvantage of using this approach is code duplication, while the adva
 1. does not contain functions (useful for debugging and usage in lamdera),
 2. does not require passing in functions when using it (cleaner API, no possibility of mistakes),
 3. live code inclusion will trim unused functions.
+
+
+### Example
+
+Say you'd like a `Dict` of `UUID.UUID`: 
+
+* First, follow elm-codegen's [docs](https://github.com/mdgriffith/elm-codegen/blob/main/guide/UsingHelpers.md), on installing packages.
+* edit the `codegen/Generate.elm` to look something like
+
+```elm
+module Generate exposing (main)
+
+import Elm
+import Elm.Annotation as Type
+import Gen.CodeGen.Generate as Generate
+import Gen.UUID as UUID
+import GenericDict
+
+
+main : Program {} () ()
+main =
+    Generate.run
+        [ customDictFile
+        ]
+
+
+customDictFile : Elm.File
+customDictFile =
+    GenericDict.init
+        { keyType = Type.namedWith [ "UUID" ] "UUID" []
+        , namespace = []
+        , toComparable = UUID.toString
+        }
+        |> GenericDict.withTypeName "UuidDict"
+        |> GenericDict.generateFile
+
+```
+
+* run `elm-codegen run` to have it create the `generated/UuidDict.elm`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The main disadvantage of using this approach is code duplication, while the adva
 
 Say you'd like a `Dict` of `UUID.UUID`: 
 
-* First, follow elm-codegen's [docs](https://github.com/mdgriffith/elm-codegen/blob/main/guide/UsingHelpers.md), on installing packages.
+* First, follow elm-codegen's [docs](https://github.com/mdgriffith/elm-codegen/blob/main/guide/UsingHelpers.md), on installing packages
 * edit the `codegen/Generate.elm` to look something like
 
 ```elm
@@ -47,3 +47,5 @@ customDictFile =
 ```
 
 * run `elm-codegen run` to have it create the `generated/UuidDict.elm`
+* update your `elm.json` to include `generated/` as a `source-directory`
+* import it as `Import UuidDict` to use it like a `UuidDict UUID.UUID a`

--- a/codegen/Gen/CodeGen/Generate.elm
+++ b/codegen/Gen/CodeGen/Generate.elm
@@ -1,7 +1,7 @@
 port module Gen.CodeGen.Generate exposing
-    ( run, fromJson, fromText
+    ( run, fromJson, fromText, fromDirectory
     , withFeedback, Error
-    , File
+    , File, Directory(..)
     , error, files, info
     )
 
@@ -10,7 +10,7 @@ port module Gen.CodeGen.Generate exposing
 
 # Simple API
 
-@docs run, fromJson, fromText
+@docs run, fromJson, fromText, fromDirectory
 
 
 # With errors
@@ -20,7 +20,7 @@ port module Gen.CodeGen.Generate exposing
 
 # Types
 
-@docs File
+@docs File, Directory
 
 
 # Flexible API
@@ -31,6 +31,7 @@ This is the low level API if you need more control over the generation process p
 
 -}
 
+import Dict exposing (Dict)
 import Json.Decode exposing (Decoder)
 import Json.Encode as Json
 
@@ -53,7 +54,6 @@ run f =
 
 
 {-| Given the flags, decoded from JSON, produce a list of files as output.
-
 -}
 fromJson : Decoder flags -> (flags -> List File) -> Program Json.Value () ()
 fromJson decoder f =
@@ -95,6 +95,74 @@ fromText f =
             \_ model ->
                 ( model, Cmd.none )
         , subscriptions = \_ -> Sub.none
+        }
+
+
+{-| Given the directory passed in with `--flags-from` as a file tree, produce a list of files as output.
+-}
+fromDirectory : (Directory -> List File) -> Program Json.Value () ()
+fromDirectory f =
+    Platform.worker
+        { init =
+            \flags ->
+                case Json.Decode.decodeValue directoryDecoder flags of
+                    Ok input ->
+                        ( ()
+                        , files (f input)
+                        )
+
+                    Err e ->
+                        ( ()
+                        , error
+                            [ { title = "Error decoding flags"
+                              , description = Json.Decode.errorToString e
+                              }
+                            ]
+                        )
+        , update =
+            \_ model ->
+                ( model, Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+directoryDecoder : Decoder Directory
+directoryDecoder =
+    Json.Decode.lazy
+        (\_ ->
+            Json.Decode.oneOf
+                [ Json.Decode.map Ok Json.Decode.string
+                , Json.Decode.map Err directoryDecoder
+                ]
+                |> Json.Decode.dict
+                |> Json.Decode.map
+                    (\entries ->
+                        entries
+                            |> Dict.toList
+                            |> List.foldl
+                                (\( name, entry ) ( dirAcc, fileAcc ) ->
+                                    case entry of
+                                        Ok file ->
+                                            ( dirAcc, ( name, file ) :: fileAcc )
+
+                                        Err directory ->
+                                            ( ( name, directory ) :: dirAcc, fileAcc )
+                                )
+                                ( [], [] )
+                            |> (\( dirAcc, fileAcc ) ->
+                                    Directory
+                                        { directories = Dict.fromList dirAcc
+                                        , files = Dict.fromList fileAcc
+                                        }
+                               )
+                    )
+        )
+
+
+type Directory
+    = Directory
+        { files : Dict String String
+        , directories : Dict String Directory
         }
 
 

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "miniBill/elm-generic-dict",
     "summary": "Codegen dictionaries with arbitrary key types.",
     "license": "BSD-3-Clause",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "exposed-modules": [
         "GenericDict"
     ],

--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm-community/string-extra": "4.0.1 <= v < 5.0.0",
-        "mdgriffith/elm-codegen": "2.0.0 <= v < 3.0.0"
+        "mdgriffith/elm-codegen": "2.0.0 <= v < 4.0.1"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/src/Gen/Array.elm
+++ b/src/Gen/Array.elm
@@ -1,7 +1,7 @@
 module Gen.Array exposing (annotation_, append, call_, empty, filter, foldl, foldr, fromList, get, indexedMap, initialize, isEmpty, length, map, moduleName_, push, repeat, set, slice, toIndexedList, toList, values_)
 
 {-| 
-@docs values_, call_, annotation_, filter, foldr, foldl, indexedMap, map, toIndexedList, toList, slice, append, push, set, get, length, isEmpty, fromList, repeat, initialize, empty, moduleName_
+@docs moduleName_, empty, initialize, repeat, fromList, isEmpty, length, get, set, push, append, slice, toList, toIndexedList, map, indexedMap, foldl, foldr, filter, annotation_, call_, values_
 -}
 
 
@@ -1163,5 +1163,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Basics.elm
+++ b/src/Gen/Basics.elm
@@ -1,7 +1,7 @@
 module Gen.Basics exposing (abs, acos, always, annotation_, asin, atan, atan2, call_, caseOf_, ceiling, clamp, compare, cos, degrees, e, floor, fromPolar, identity, isInfinite, isNaN, logBase, make_, max, min, modBy, moduleName_, negate, never, not, pi, radians, remainderBy, round, sin, sqrt, tan, toFloat, toPolar, truncate, turns, values_, xor)
 
 {-| 
-@docs values_, call_, caseOf_, make_, annotation_, never, always, identity, isInfinite, isNaN, fromPolar, toPolar, atan2, atan, asin, acos, tan, sin, cos, pi, turns, radians, degrees, e, logBase, sqrt, clamp, abs, negate, remainderBy, modBy, xor, not, compare, min, max, truncate, ceiling, floor, round, toFloat, moduleName_
+@docs moduleName_, toFloat, round, floor, ceiling, truncate, max, min, compare, not, xor, modBy, remainderBy, negate, abs, clamp, sqrt, logBase, e, degrees, radians, turns, pi, cos, sin, tan, acos, asin, atan, atan2, toPolar, fromPolar, isNaN, isInfinite, identity, always, never, annotation_, make_, caseOf_, call_, values_
 -}
 
 
@@ -1676,5 +1676,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Bitwise.elm
+++ b/src/Gen/Bitwise.elm
@@ -1,7 +1,7 @@
 module Gen.Bitwise exposing (and, call_, complement, moduleName_, or, shiftLeftBy, shiftRightBy, shiftRightZfBy, values_, xor)
 
 {-| 
-@docs values_, call_, shiftRightZfBy, shiftRightBy, shiftLeftBy, complement, xor, or, and, moduleName_
+@docs moduleName_, and, or, xor, complement, shiftLeftBy, shiftRightBy, shiftRightZfBy, call_, values_
 -}
 
 
@@ -294,5 +294,3 @@ values_ =
             , annotation = Just (Type.function [ Type.int, Type.int ] Type.int)
             }
     }
-
-

--- a/src/Gen/Char.elm
+++ b/src/Gen/Char.elm
@@ -1,7 +1,7 @@
 module Gen.Char exposing (annotation_, call_, fromCode, isAlpha, isAlphaNum, isDigit, isHexDigit, isLower, isOctDigit, isUpper, moduleName_, toCode, toLocaleLower, toLocaleUpper, toLower, toUpper, values_)
 
 {-| 
-@docs values_, call_, annotation_, fromCode, toCode, toLocaleLower, toLocaleUpper, toLower, toUpper, isHexDigit, isOctDigit, isDigit, isAlphaNum, isAlpha, isLower, isUpper, moduleName_
+@docs moduleName_, isUpper, isLower, isAlpha, isAlphaNum, isDigit, isOctDigit, isHexDigit, toUpper, toLower, toLocaleUpper, toLocaleLower, toCode, fromCode, annotation_, call_, values_
 -}
 
 
@@ -550,5 +550,3 @@ values_ =
             , annotation = Just (Type.function [ Type.int ] Type.char)
             }
     }
-
-

--- a/src/Gen/Debug.elm
+++ b/src/Gen/Debug.elm
@@ -1,7 +1,7 @@
 module Gen.Debug exposing (call_, log, moduleName_, toString, todo, values_)
 
 {-| 
-@docs values_, call_, todo, log, toString, moduleName_
+@docs moduleName_, toString, log, todo, call_, values_
 -}
 
 
@@ -194,5 +194,3 @@ values_ =
             , annotation = Just (Type.function [ Type.string ] (Type.var "a"))
             }
     }
-
-

--- a/src/Gen/Dict.elm
+++ b/src/Gen/Dict.elm
@@ -1,7 +1,7 @@
 module Gen.Dict exposing (annotation_, call_, diff, empty, filter, foldl, foldr, fromList, get, insert, intersect, isEmpty, keys, map, member, merge, moduleName_, partition, remove, singleton, size, toList, union, update, values, values_)
 
 {-| 
-@docs values_, call_, annotation_, merge, diff, intersect, union, partition, filter, foldr, foldl, map, fromList, toList, values, keys, size, get, member, isEmpty, remove, update, insert, singleton, empty, moduleName_
+@docs moduleName_, empty, singleton, insert, update, remove, isEmpty, member, get, size, keys, values, toList, fromList, map, foldl, foldr, filter, partition, union, intersect, diff, merge, annotation_, call_, values_
 -}
 
 
@@ -1881,5 +1881,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/FastDict.elm
+++ b/src/Gen/FastDict.elm
@@ -1,7 +1,7 @@
 module Gen.FastDict exposing (annotation_, call_, diff, empty, equals, filter, foldl, foldr, fromCoreDict, fromList, get, getMax, getMaxKey, getMin, getMinKey, insert, intersect, isEmpty, keys, map, member, merge, moduleName_, partition, popMax, popMin, remove, singleton, size, toCoreDict, toList, union, update, values, values_)
 
 {-| 
-@docs values_, call_, annotation_, fromCoreDict, toCoreDict, merge, diff, intersect, union, partition, filter, foldr, foldl, map, fromList, toList, values, keys, popMax, popMin, getMax, getMaxKey, getMin, getMinKey, equals, size, get, member, isEmpty, remove, update, insert, singleton, empty, moduleName_
+@docs moduleName_, empty, singleton, insert, update, remove, isEmpty, member, get, size, equals, getMinKey, getMin, getMaxKey, getMax, popMin, popMax, keys, values, toList, fromList, map, foldl, foldr, filter, partition, union, intersect, diff, merge, toCoreDict, fromCoreDict, annotation_, call_, values_
 -}
 
 
@@ -2665,5 +2665,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/List.elm
+++ b/src/Gen/List.elm
@@ -1,7 +1,7 @@
 module Gen.List exposing (all, any, append, call_, concat, concatMap, drop, filter, filterMap, foldl, foldr, head, indexedMap, intersperse, isEmpty, length, map, map2, map3, map4, map5, maximum, member, minimum, moduleName_, partition, product, range, repeat, reverse, singleton, sort, sortBy, sortWith, sum, tail, take, unzip, values_)
 
 {-| 
-@docs values_, call_, unzip, partition, drop, take, tail, head, isEmpty, sortWith, sortBy, sort, map5, map4, map3, map2, intersperse, concatMap, concat, append, product, sum, minimum, maximum, any, all, member, reverse, length, filterMap, filter, foldr, foldl, indexedMap, map, range, repeat, singleton, moduleName_
+@docs moduleName_, singleton, repeat, range, map, indexedMap, foldl, foldr, filter, filterMap, length, reverse, member, all, any, maximum, minimum, sum, product, append, concat, concatMap, intersperse, map2, map3, map4, map5, sort, sortBy, sortWith, isEmpty, head, tail, take, drop, partition, unzip, call_, values_
 -}
 
 
@@ -2336,5 +2336,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Maybe.elm
+++ b/src/Gen/Maybe.elm
@@ -1,7 +1,7 @@
 module Gen.Maybe exposing (andThen, annotation_, call_, caseOf_, make_, map, map2, map3, map4, map5, moduleName_, values_, withDefault)
 
 {-| 
-@docs values_, call_, caseOf_, make_, annotation_, andThen, map5, map4, map3, map2, map, withDefault, moduleName_
+@docs moduleName_, withDefault, map, map2, map3, map4, map5, andThen, annotation_, make_, caseOf_, call_, values_
 -}
 
 
@@ -726,5 +726,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Platform.elm
+++ b/src/Gen/Platform.elm
@@ -1,13 +1,12 @@
 module Gen.Platform exposing (annotation_, call_, moduleName_, sendToApp, sendToSelf, values_, worker)
 
 {-| 
-@docs values_, call_, annotation_, sendToSelf, sendToApp, worker, moduleName_
+@docs moduleName_, worker, sendToApp, sendToSelf, annotation_, call_, values_
 -}
 
 
 import Elm
 import Elm.Annotation as Type
-import Tuple
 
 
 {-| The name of this module. -}
@@ -420,5 +419,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Platform/Cmd.elm
+++ b/src/Gen/Platform/Cmd.elm
@@ -1,7 +1,7 @@
 module Gen.Platform.Cmd exposing (annotation_, batch, call_, map, moduleName_, none, values_)
 
 {-| 
-@docs values_, call_, annotation_, map, batch, none, moduleName_
+@docs moduleName_, none, batch, map, annotation_, call_, values_
 -}
 
 
@@ -12,7 +12,7 @@ import Elm.Annotation as Type
 {-| The name of this module. -}
 moduleName_ : List String
 moduleName_ =
-    [ "Platform", "Cmd" ]
+    [ "Cmd" ]
 
 
 {-| Tell the runtime that there are no commands.
@@ -22,7 +22,7 @@ none: Platform.Cmd.Cmd msg
 none : Elm.Expression
 none =
     Elm.value
-        { importFrom = [ "Platform", "Cmd" ]
+        { importFrom = [ "Cmd" ]
         , name = "none"
         , annotation = Just (Type.namedWith [] "Cmd" [ Type.var "msg" ])
         }
@@ -42,7 +42,7 @@ batch : List Elm.Expression -> Elm.Expression
 batch batchArg =
     Elm.apply
         (Elm.value
-            { importFrom = [ "Platform", "Cmd" ]
+            { importFrom = [ "Cmd" ]
             , name = "batch"
             , annotation =
                 Just
@@ -70,7 +70,7 @@ map : (Elm.Expression -> Elm.Expression) -> Elm.Expression -> Elm.Expression
 map mapArg mapArg0 =
     Elm.apply
         (Elm.value
-            { importFrom = [ "Platform", "Cmd" ]
+            { importFrom = [ "Cmd" ]
             , name = "map"
             , annotation =
                 Just
@@ -87,7 +87,7 @@ map mapArg mapArg0 =
 
 annotation_ : { cmd : Type.Annotation -> Type.Annotation }
 annotation_ =
-    { cmd = \cmdArg0 -> Type.namedWith [] "Cmd" [ cmdArg0 ] }
+    { cmd = \cmdArg0 -> Type.namedWith [ "Cmd" ] "Cmd" [ cmdArg0 ] }
 
 
 call_ :
@@ -99,7 +99,7 @@ call_ =
         \batchArg ->
             Elm.apply
                 (Elm.value
-                    { importFrom = [ "Platform", "Cmd" ]
+                    { importFrom = [ "Cmd" ]
                     , name = "batch"
                     , annotation =
                         Just
@@ -116,7 +116,7 @@ call_ =
         \mapArg mapArg0 ->
             Elm.apply
                 (Elm.value
-                    { importFrom = [ "Platform", "Cmd" ]
+                    { importFrom = [ "Cmd" ]
                     , name = "map"
                     , annotation =
                         Just
@@ -139,13 +139,13 @@ values_ :
 values_ =
     { none =
         Elm.value
-            { importFrom = [ "Platform", "Cmd" ]
+            { importFrom = [ "Cmd" ]
             , name = "none"
             , annotation = Just (Type.namedWith [] "Cmd" [ Type.var "msg" ])
             }
     , batch =
         Elm.value
-            { importFrom = [ "Platform", "Cmd" ]
+            { importFrom = [ "Cmd" ]
             , name = "batch"
             , annotation =
                 Just
@@ -157,7 +157,7 @@ values_ =
             }
     , map =
         Elm.value
-            { importFrom = [ "Platform", "Cmd" ]
+            { importFrom = [ "Cmd" ]
             , name = "map"
             , annotation =
                 Just
@@ -169,5 +169,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Platform/Sub.elm
+++ b/src/Gen/Platform/Sub.elm
@@ -1,7 +1,7 @@
 module Gen.Platform.Sub exposing (annotation_, batch, call_, map, moduleName_, none, values_)
 
 {-| 
-@docs values_, call_, annotation_, map, batch, none, moduleName_
+@docs moduleName_, none, batch, map, annotation_, call_, values_
 -}
 
 
@@ -12,7 +12,7 @@ import Elm.Annotation as Type
 {-| The name of this module. -}
 moduleName_ : List String
 moduleName_ =
-    [ "Platform", "Sub" ]
+    [ "Sub" ]
 
 
 {-| Tell the runtime that there are no subscriptions.
@@ -22,7 +22,7 @@ none: Platform.Sub.Sub msg
 none : Elm.Expression
 none =
     Elm.value
-        { importFrom = [ "Platform", "Sub" ]
+        { importFrom = [ "Sub" ]
         , name = "none"
         , annotation = Just (Type.namedWith [] "Sub" [ Type.var "msg" ])
         }
@@ -40,7 +40,7 @@ batch : List Elm.Expression -> Elm.Expression
 batch batchArg =
     Elm.apply
         (Elm.value
-            { importFrom = [ "Platform", "Sub" ]
+            { importFrom = [ "Sub" ]
             , name = "batch"
             , annotation =
                 Just
@@ -68,7 +68,7 @@ map : (Elm.Expression -> Elm.Expression) -> Elm.Expression -> Elm.Expression
 map mapArg mapArg0 =
     Elm.apply
         (Elm.value
-            { importFrom = [ "Platform", "Sub" ]
+            { importFrom = [ "Sub" ]
             , name = "map"
             , annotation =
                 Just
@@ -85,7 +85,7 @@ map mapArg mapArg0 =
 
 annotation_ : { sub : Type.Annotation -> Type.Annotation }
 annotation_ =
-    { sub = \subArg0 -> Type.namedWith [] "Sub" [ subArg0 ] }
+    { sub = \subArg0 -> Type.namedWith [ "Sub" ] "Sub" [ subArg0 ] }
 
 
 call_ :
@@ -97,7 +97,7 @@ call_ =
         \batchArg ->
             Elm.apply
                 (Elm.value
-                    { importFrom = [ "Platform", "Sub" ]
+                    { importFrom = [ "Sub" ]
                     , name = "batch"
                     , annotation =
                         Just
@@ -114,7 +114,7 @@ call_ =
         \mapArg mapArg0 ->
             Elm.apply
                 (Elm.value
-                    { importFrom = [ "Platform", "Sub" ]
+                    { importFrom = [ "Sub" ]
                     , name = "map"
                     , annotation =
                         Just
@@ -137,13 +137,13 @@ values_ :
 values_ =
     { none =
         Elm.value
-            { importFrom = [ "Platform", "Sub" ]
+            { importFrom = [ "Sub" ]
             , name = "none"
             , annotation = Just (Type.namedWith [] "Sub" [ Type.var "msg" ])
             }
     , batch =
         Elm.value
-            { importFrom = [ "Platform", "Sub" ]
+            { importFrom = [ "Sub" ]
             , name = "batch"
             , annotation =
                 Just
@@ -155,7 +155,7 @@ values_ =
             }
     , map =
         Elm.value
-            { importFrom = [ "Platform", "Sub" ]
+            { importFrom = [ "Sub" ]
             , name = "map"
             , annotation =
                 Just
@@ -167,5 +167,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Process.elm
+++ b/src/Gen/Process.elm
@@ -1,7 +1,7 @@
 module Gen.Process exposing (annotation_, call_, kill, moduleName_, sleep, spawn, values_)
 
 {-| 
-@docs values_, call_, annotation_, kill, sleep, spawn, moduleName_
+@docs moduleName_, spawn, sleep, kill, annotation_, call_, values_
 -}
 
 
@@ -251,5 +251,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Result.elm
+++ b/src/Gen/Result.elm
@@ -1,7 +1,7 @@
 module Gen.Result exposing (andThen, annotation_, call_, caseOf_, fromMaybe, make_, map, map2, map3, map4, map5, mapError, moduleName_, toMaybe, values_, withDefault)
 
 {-| 
-@docs values_, call_, caseOf_, make_, annotation_, mapError, fromMaybe, toMaybe, withDefault, andThen, map5, map4, map3, map2, map, moduleName_
+@docs moduleName_, map, map2, map3, map4, map5, andThen, withDefault, toMaybe, fromMaybe, mapError, annotation_, make_, caseOf_, call_, values_
 -}
 
 
@@ -1229,5 +1229,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Set.elm
+++ b/src/Gen/Set.elm
@@ -1,7 +1,7 @@
 module Gen.Set exposing (annotation_, call_, diff, empty, filter, foldl, foldr, fromList, insert, intersect, isEmpty, map, member, moduleName_, partition, remove, singleton, size, toList, union, values_)
 
 {-| 
-@docs values_, call_, annotation_, partition, filter, foldr, foldl, map, fromList, toList, diff, intersect, union, size, member, isEmpty, remove, insert, singleton, empty, moduleName_
+@docs moduleName_, empty, singleton, insert, remove, isEmpty, member, size, union, intersect, diff, toList, fromList, map, foldl, foldr, filter, partition, annotation_, call_, values_
 -}
 
 
@@ -1238,5 +1238,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/String.elm
+++ b/src/Gen/String.elm
@@ -1,7 +1,7 @@
 module Gen.String exposing (all, annotation_, any, append, call_, concat, cons, contains, dropLeft, dropRight, endsWith, filter, foldl, foldr, fromChar, fromFloat, fromInt, fromList, indexes, indices, isEmpty, join, left, length, lines, map, moduleName_, pad, padLeft, padRight, repeat, replace, reverse, right, slice, split, startsWith, toFloat, toInt, toList, toLower, toUpper, trim, trimLeft, trimRight, uncons, values_, words)
 
 {-| 
-@docs values_, call_, annotation_, all, any, foldr, foldl, filter, map, trimRight, trimLeft, trim, padRight, padLeft, pad, toLower, toUpper, fromList, toList, uncons, cons, fromChar, fromFloat, toFloat, fromInt, toInt, indices, indexes, endsWith, startsWith, contains, dropRight, dropLeft, right, left, slice, lines, words, join, split, concat, append, replace, repeat, reverse, length, isEmpty, moduleName_
+@docs moduleName_, isEmpty, length, reverse, repeat, replace, append, concat, split, join, words, lines, slice, left, right, dropLeft, dropRight, contains, startsWith, endsWith, indexes, indices, toInt, fromInt, toFloat, fromFloat, fromChar, cons, uncons, toList, fromList, toUpper, toLower, pad, padLeft, padRight, trim, trimLeft, trimRight, map, filter, foldl, foldr, any, all, annotation_, call_, values_
 -}
 
 
@@ -2096,5 +2096,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Task.elm
+++ b/src/Gen/Task.elm
@@ -1,7 +1,7 @@
 module Gen.Task exposing (andThen, annotation_, attempt, call_, fail, map, map2, map3, map4, map5, mapError, moduleName_, onError, perform, sequence, succeed, values_)
 
 {-| 
-@docs values_, call_, annotation_, mapError, onError, map5, map4, map3, map2, map, sequence, fail, succeed, andThen, attempt, perform, moduleName_
+@docs moduleName_, perform, attempt, andThen, succeed, fail, sequence, map, map2, map3, map4, map5, onError, mapError, annotation_, call_, values_
 -}
 
 
@@ -1470,5 +1470,3 @@ values_ =
                     )
             }
     }
-
-

--- a/src/Gen/Tuple.elm
+++ b/src/Gen/Tuple.elm
@@ -1,7 +1,7 @@
 module Gen.Tuple exposing (call_, first, mapBoth, mapFirst, mapSecond, moduleName_, pair, second, values_)
 
 {-| 
-@docs values_, call_, mapBoth, mapSecond, mapFirst, second, first, pair, moduleName_
+@docs moduleName_, pair, first, second, mapFirst, mapSecond, mapBoth, call_, values_
 -}
 
 
@@ -375,5 +375,3 @@ values_ =
                     )
             }
     }
-
-


### PR DESCRIPTION
I bumped the elm-codegen version, and added a little example to the README.

I ran `make all -B` and it rebuilt the Gen/ files. Seems like everything is working; it built before and after incrementing the library version.

`elm-json upgrade` threw a NOT SUPPORTED error, so I manually changed the version numbers myself.

Let me know if I can improve the PR at all. This is my first commit to an elm package, so I might have done this wrong!